### PR TITLE
Documentation update for /training_logs/years endpoint

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3368,6 +3368,13 @@ paths:
   /training_logs/years:
     get:
       operationId: training_logs_years_index
+      parameters:
+        - description: Sport Id values that need to be considered for filter
+          in: query
+          name: sport_id
+          required: false
+          schema:
+            type: integer
       responses:
         '200':
           description: No response was specified


### PR DESCRIPTION
Trello card: [Add sport_id filter to `training_logs` years endpoint](https://trello.com/c/qYlbRSRL)

Related PR https://github.com/HeiaHeia/HeiaHeia/pull/7715